### PR TITLE
Implements default miscellaneous group 

### DIFF
--- a/src/install.js
+++ b/src/install.js
@@ -420,6 +420,24 @@ async function createGlobalModeratorsGroup() {
     await groups.show('Global Moderators');
 }
 
+async function createMiscellaneousGroup() {
+    const groups = require('./groups');
+    const exists = await groups.exists('Miscellaneous');
+    if (exists) {
+        winston.info('Miscellaneous group found, skipping creation!');
+    } else {
+        await groups.create({
+            name: 'Miscellaneous',
+            userTitle: 'Miscellaneous',
+            description: 'For Unmatched Posts',
+            hidden: 0,
+            private: 0,
+            disableJoinRequests: 1,
+        });
+    }
+    await groups.show('Miscellaneous');
+}
+
 async function giveGlobalPrivileges() {
     const privileges = require('./privileges');
     const defaultPrivileges = [
@@ -575,6 +593,7 @@ install.setup = async function () {
         const adminInfo = await createAdministrator();
         await createGlobalModeratorsGroup();
         await giveGlobalPrivileges();
+        await createMiscellaneousGroup();
         await createMenuItems();
         await createWelcomePost();
         await enableDefaultPlugins();


### PR DESCRIPTION
Creates a default miscellaneous group when someone open up NodeBB. Group is public and works as expected with previously implemented filter, but admin needs to add themself to the group first (like all other classes where in order to see posts from specific members they must be a part of that group).

Resolves #24 