### PR TITLE
Implements default miscellaneous group

### DIFF
--- a/src/install.js
+++ b/src/install.js
@@ -10,6 +10,8 @@ const _ = require('lodash');
 
 const utils = require('./utils');
 
+const createMiscellaneousGroup = require('./miscellaneous').default;
+
 const install = module.exports;
 const questions = {};
 
@@ -418,24 +420,6 @@ async function createGlobalModeratorsGroup() {
         });
     }
     await groups.show('Global Moderators');
-}
-
-async function createMiscellaneousGroup() {
-    const groups = require('./groups');
-    const exists = await groups.exists('Miscellaneous');
-    if (exists) {
-        winston.info('Miscellaneous group found, skipping creation!');
-    } else {
-        await groups.create({
-            name: 'Miscellaneous',
-            userTitle: 'Miscellaneous',
-            description: 'For Unmatched Posts',
-            hidden: 0,
-            private: 0,
-            disableJoinRequests: 1,
-        });
-    }
-    await groups.show('Miscellaneous');
 }
 
 async function giveGlobalPrivileges() {

--- a/src/install.js
+++ b/src/install.js
@@ -420,6 +420,24 @@ async function createGlobalModeratorsGroup() {
     await groups.show('Global Moderators');
 }
 
+async function createMiscellaneousGroup() {
+    const groups = require('./groups');
+    const exists = await groups.exists('Miscellaneous');
+    if (exists) {
+        winston.info('Miscellaneous group found, skipping creation!');
+    } else {
+        await groups.create({
+            name: 'Miscellaneous',
+            userTitle: 'Miscellaneous',
+            description: 'For Unmatched Posts',
+            hidden: 0,
+            private: 0,
+            disableJoinRequests: 1,
+        });
+    }
+    await groups.show('Miscellaneous');
+}
+
 async function giveGlobalPrivileges() {
     const privileges = require('./privileges');
     const defaultPrivileges = [
@@ -575,6 +593,7 @@ install.setup = async function () {
         const adminInfo = await createAdministrator();
         await createGlobalModeratorsGroup();
         await giveGlobalPrivileges();
+        await createMiscellaneousGroup();
         await createMenuItems();
         await createWelcomePost();
         await enableDefaultPlugins();

--- a/src/miscellaneous.js
+++ b/src/miscellaneous.js
@@ -1,0 +1,59 @@
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const winston = __importStar(require("winston"));
+const groups = __importStar(require("./groups"));
+function createMiscellaneousGroup() {
+    return __awaiter(this, void 0, void 0, function* () {
+        const exists = yield groups.exists('Miscellaneous');
+        if (exists) {
+            winston.info('Miscellaneous group found, skipping creation!');
+        }
+        else {
+            const config = {
+                name: 'Miscellaneous',
+                userTitle: 'Miscellaneous',
+                description: 'For Unmatched Posts',
+                hidden: 0,
+                private: 0,
+                disableJoinRequests: 1,
+            };
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+            yield groups.create(config);
+        }
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+        yield groups.show('Miscellaneous');
+    });
+}
+exports.default = createMiscellaneousGroup;

--- a/src/miscellaneous.ts
+++ b/src/miscellaneous.ts
@@ -1,0 +1,31 @@
+import * as winston from 'winston';
+import * as groups from './groups';
+
+async function createMiscellaneousGroup(): Promise<void> {
+    const exists: boolean = await groups.exists('Miscellaneous') as boolean;
+    if (exists) {
+        winston.info('Miscellaneous group found, skipping creation!');
+    } else {
+        const config: {
+            name: string;
+            userTitle: string;
+            description: string;
+            hidden: number;
+            private: number;
+            disableJoinRequests: number;
+        } = {
+            name: 'Miscellaneous',
+            userTitle: 'Miscellaneous',
+            description: 'For Unmatched Posts',
+            hidden: 0,
+            private: 0,
+            disableJoinRequests: 1,
+        };
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+        await groups.create(config);
+    }
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+    await groups.show('Miscellaneous');
+}
+
+export default createMiscellaneousGroup;


### PR DESCRIPTION
Creates a default miscellaneous group when someone open up NodeBB. Group is public and works as expected with previously implemented filter, but admin needs to add themself to the group first (like all other classes where in order to see posts from specific members they must be a part of that group).

Resolves https://github.com/CMU-313/fall23-nodebb-fam/issues/24