### PR TITLE
Tests made for misc group, filtering posts, and timestamp features; UserGuide.md added

### DIFF
--- a/UserGuide.md
+++ b/UserGuide.md
@@ -1,34 +1,71 @@
-- follow rest of userguide.md and add screenshots into the PR's
+Testing our Features:
 
-- categories.js
-    - deleted topic titles with regex
-- controllers.js
-    - sorted topics and topics from a specific users topics from a category with tags have correct timestamps (search for &#x2F;)
-- posts.js
-    - should bypass post queue if user is in exempt group &#x2F
-- search.js
-    - child categories check for correct ones if u search for regex
-- topics.js (bulk)
-    - posting a new topic
-    - escaping a title
-    - return topics
-    - merging topics
-    - search for "+ ' ("
-    - scheduled timestamps
-- user.js
-    - banned topics check with regex
+Within the following existing test files, you will find edited tests and new tests. The existing test files contain a comprehensive collection of tests for ensuring the reliability of the code. We leverage NodeBB's existing tests by editing them to fit our new functionality. Additionally, we implemented new tests to account for any other cases that NodeBB would not have made due to any edge cases with our new features.
 
-filtering
-- controllers.js (lines 926-967)
-    - checks that the post group-details goes in the group-details group
-    - also checks that a post without the group name in its title does not show in the group at all
+1. Miscellaneous group and Miscellaneous filter
 
-misc group and misc filter
-- controllers.js (lines 969-995)
-    - checks that you can join the group without having to create it (this isn't implemented because I don't know how)
-    - checks that an umnatched post goes inside misc; this post title does not have miscellaneous in it, but it still shows up
-        - this combined with the previous test in filtering section affirm that posts only show up in other groups when they match, but only in misc when they don't match
-- groups.js
-    - user can be safely added to miscellaneous group "should add user to Miscellaneous group"
+The following tests combined with the tests mentioned under 'Filter feature' affirm that posts only show up in other groups when their titles match, but only in the miscellaneous group when they don't match. This covers all cases for filtering with relation to this default group. It also confirms that, like the global moderators group, users are presented with a miscellaneous group and can join said group.
+
+- test/controllers.js
+    - Search for 'should load misc page and filter unmatched posts in that group' within this file
+    - Tests that an umnatched post goes inside the Miscellaneous group; this post title does not have miscellaneous in it, but it still shows up (expected behavior)
+    
+- test/groups.js
+    - Search for 'should add user to Miscellaneous group' within this file
+    - Ensures that a user can be added to this default group
+
+2. Filter feature
+
+The two scenarios of a post appearing in a group and not appearing in a group are covered with these tests. This is comprehensive for the filtering feature.
+
+- test/controllers.js 
+    - Search for 'should load group details page' within this file
+    - Tests that the post titled 'group-details' goes in the group-details group
+    - Tests that a post without 'group-details' in its title does not show in the group-details group
+
+3. Timestamp feature
+
+Our tests ensure that a timestamp shows up in any post made by editing existing tests where titles were checked to now include timestamps. It also tests that new posts have timestamps in it.
+
+- test/categories.js
+    - Search for 'should not show deleted topic titles' within this file 
+    - This test uses a Regex to ensure that any deleted topic title stays deleted and matches its original title with a timestamp
+- test/controllers.js
+    - Search for '&#x2F;' within this file (this is the HEX code for '\' which is used in the timestamp)
+    - Any instance of that string represents a test for this file
+        - Checks that sorted topics have the correct timestamp and that timestamps are used in the sorting process
+        - Checks that a specific user's topics from a category with tags have correct timestamps 
+- test/posts.js
+    - Search for 'should bypass post queue if user is in exempt group' within this file 
+    - This test uses a Regex to ensure that if a user is in the exempt group, their post publishes first even when queued with a timestamp
+- test/search.js
+    - Search for 'regex' within this file 
+    - This test uses a Regex to ensure that posts within child categories contain timestamps
+- test/topics.js (contains the bulk of the testing logic)
+    - Search for 'formattedTimestamp' within this file
+    - Tests for adding a timestamp into a published post
+    - Tests that timestamps work fine when escaping a topic title
+    - Tests that related topics contain timestamps in their titles
+    - Tests that different cases for merging topics result in a topic with a timestamp in its title
+    - Tests that recently replied topics have a timestamp in them
+    - Tests that a scheduled post has a timestamp in it when published
+- test/user.js
+    - Search for 'regex' within this file
+    - Ensures that categories with banned users can still contain valid posts with timestamps
 
 
+Using our Features:
+
+Before beginning any testing, please run redis-cli FLUSHALL in your terminal. Then, setup the codebase again with ./nodebb setup (make sure to store the admin password shown at the end) and start the NodeBB server.
+
+1. Viewing a default Miscellaneous Group
+
+    Begin by searching the navigation bar for the classes category or clicking on the classes category from the index page. There, you will be redirected to the classes/groups page. On this page, you should see a group titled 'Miscellaneous'. Click on the group. Once inside the group, use the left panel to add yourself (admin) as a member of the group. 
+
+2. Filtering posts and grouping posts within classes
+
+    From the classes/groups page, create another class titled 17-313. Navigate back to the home page. Under the category 'Exams', create two posts/topics using the button in the top left. In one of them, add 17-313 in the title of the post. In the other one, add extraneous information, but DO NOT add '17-313' or 'Miscellaneous' in the title of the post. After successfully making two posts, navigate to the classes page. Click on your 17-313 class; expand the 'Exams' group you should see your first post with 17-313 in the title but not your second post. Go back to the classes page and click on your Miscellaneous group; you expand the 'Exams' group and you should see the second post but not the first post. You shoudl not see any other posts in any of the other groups.
+
+3. Viewing timestamp in post title
+
+    You should be able to view the timestamp of a post in the post title after successfully publishing a post.

--- a/UserGuide.md
+++ b/UserGuide.md
@@ -1,0 +1,34 @@
+- follow rest of userguide.md and add screenshots into the PR's
+
+- categories.js
+    - deleted topic titles with regex
+- controllers.js
+    - sorted topics and topics from a specific users topics from a category with tags have correct timestamps (search for &#x2F;)
+- posts.js
+    - should bypass post queue if user is in exempt group &#x2F
+- search.js
+    - child categories check for correct ones if u search for regex
+- topics.js (bulk)
+    - posting a new topic
+    - escaping a title
+    - return topics
+    - merging topics
+    - search for "+ ' ("
+    - scheduled timestamps
+- user.js
+    - banned topics check with regex
+
+filtering
+- controllers.js (lines 926-967)
+    - checks that the post group-details goes in the group-details group
+    - also checks that a post without the group name in its title does not show in the group at all
+
+misc group and misc filter
+- controllers.js (lines 969-995)
+    - checks that you can join the group without having to create it (this isn't implemented because I don't know how)
+    - checks that an umnatched post goes inside misc; this post title does not have miscellaneous in it, but it still shows up
+        - this combined with the previous test in filtering section affirm that posts only show up in other groups when they match, but only in misc when they don't match
+- groups.js
+    - user can be safely added to miscellaneous group "should add user to Miscellaneous group"
+
+

--- a/UserGuide.md
+++ b/UserGuide.md
@@ -1,4 +1,4 @@
-Testing our Features:
+# Testing our Features:
 
 Within the following existing test files, you will find edited tests and new tests. The existing test files contain a comprehensive collection of tests for ensuring the reliability of the code. We leverage NodeBB's existing tests by editing them to fit our new functionality. Additionally, we implemented new tests to account for any other cases that NodeBB would not have made due to any edge cases with our new features.
 
@@ -54,7 +54,7 @@ Our tests ensure that a timestamp shows up in any post made by editing existing 
     - Ensures that categories with banned users can still contain valid posts with timestamps
 
 
-Using our Features:
+# Using our Features:
 
 Before beginning any testing, please run redis-cli FLUSHALL in your terminal. Then, setup the codebase again with ./nodebb setup (make sure to store the admin password shown at the end) and start the NodeBB server.
 

--- a/src/topics/create.js
+++ b/src/topics/create.js
@@ -14,7 +14,6 @@ const posts = require('../posts');
 const privileges = require('../privileges');
 const categories = require('../categories');
 const translator = require('../translator');
-const Categories = require('../categories');
 
 module.exports = function (Topics) {
     Topics.create = async function (data) {
@@ -37,8 +36,7 @@ module.exports = function (Topics) {
         };
 
         const formattedTimestamp = new Date(topicData.timestamp).toLocaleString();
-        topicData.title = data.title + ' (' + formattedTimestamp + ')';
-        
+        topicData.title = `${data.title} (${formattedTimestamp})`;
         if (Array.isArray(data.tags) && data.tags.length) {
             topicData.tags = data.tags.join(',');
         }

--- a/src/topics/create.js
+++ b/src/topics/create.js
@@ -39,7 +39,6 @@ module.exports = function (Topics) {
         const formattedTimestamp = new Date(topicData.timestamp).toLocaleString();
         topicData.title = data.title + ' (' + formattedTimestamp + ')';
         
-        
         if (Array.isArray(data.tags) && data.tags.length) {
             topicData.tags = data.tags.join(',');
         }

--- a/src/topics/recent.js
+++ b/src/topics/recent.js
@@ -69,13 +69,11 @@ module.exports = function (Topics) {
 
     Topics.updateRecent = async function (tid, timestamp) {
         let data = { tid: tid, timestamp: timestamp };
-        const formattedTimestamp = new Date(timestamp).toLocaleString();
         if (plugins.hooks.hasListeners('filter:topics.updateRecent')) {
-            data = await plugins.hooks.fire('filter:topics.updateRecent', { tid: tid, title: title + ' (' + formattedTimestamp + ')', timestamp: timestamp });
+            data = await plugins.hooks.fire('filter:topics.updateRecent', { tid: tid, timestamp: timestamp });
         }
         if (data && data.tid && data.timestamp) {
             await db.sortedSetAdd('topics:recent', data.timestamp, data.tid);
         }
-
     };
 };

--- a/src/topics/recent.js
+++ b/src/topics/recent.js
@@ -69,11 +69,13 @@ module.exports = function (Topics) {
 
     Topics.updateRecent = async function (tid, timestamp) {
         let data = { tid: tid, timestamp: timestamp };
+        const formattedTimestamp = new Date(timestamp).toLocaleString();
         if (plugins.hooks.hasListeners('filter:topics.updateRecent')) {
-            data = await plugins.hooks.fire('filter:topics.updateRecent', { tid: tid, timestamp: timestamp });
+            data = await plugins.hooks.fire('filter:topics.updateRecent', { tid: tid, title: title + ' (' + formattedTimestamp + ')', timestamp: timestamp });
         }
         if (data && data.tid && data.timestamp) {
             await db.sortedSetAdd('topics:recent', data.timestamp, data.tid);
         }
+
     };
 };

--- a/test/categories.js
+++ b/test/categories.js
@@ -267,19 +267,15 @@ describe('Categories', () => {
                 cid: categoryObj.cid,
                 after: 0,
             });
-        
             // Define a regex pattern for Test Topic Title
             const regexPattern = /^Test Topic Title \((1[0-2]|0[1-9])&#x2F;(3[01]|[12][0-9]|0[1-9])&#x2F;\d{4}, (1[0-2]|[1-9]):([0-5][0-9]):([0-5][0-9]) (AM|PM)\)$/;
-        
             // Ensure the first element is the deleted topic marker
             assert.strictEqual(data.topics.map(t => t.title)[0], '[[topic:topic_is_deleted]]', 'First topic should be deleted');
-        
             // Check each topic title against the regex pattern, skipping the first element
-            data.topics.slice(1).forEach(t => {
+            data.topics.slice(1).forEach((t) => {
                 assert.ok(regexPattern.test(t.title), `Topic title "${t.title}" does not match the expected pattern`);
             });
         });
-        
 
         it('should load topic count', (done) => {
             socketCategories.getTopicCount({ uid: posterUid }, categoryObj.cid, (err, topicCount) => {

--- a/test/categories.js
+++ b/test/categories.js
@@ -267,12 +267,19 @@ describe('Categories', () => {
                 cid: categoryObj.cid,
                 after: 0,
             });
-
-            assert.deepStrictEqual(
-                data.topics.map(t => t.title),
-                ['[[topic:topic_is_deleted]]', 'Test Topic Title', 'Test Topic Title'],
-            );
+        
+            // Define a regex pattern for Test Topic Title
+            const regexPattern = /^Test Topic Title \((1[0-2]|0[1-9])&#x2F;(3[01]|[12][0-9]|0[1-9])&#x2F;\d{4}, (1[0-2]|[1-9]):([0-5][0-9]):([0-5][0-9]) (AM|PM)\)$/;
+        
+            // Ensure the first element is the deleted topic marker
+            assert.strictEqual(data.topics.map(t => t.title)[0], '[[topic:topic_is_deleted]]', 'First topic should be deleted');
+        
+            // Check each topic title against the regex pattern, skipping the first element
+            data.topics.slice(1).forEach(t => {
+                assert.ok(regexPattern.test(t.title), `Topic title "${t.title}" does not match the expected pattern`);
+            });
         });
+        
 
         it('should load topic count', (done) => {
             socketCategories.getTopicCount({ uid: posterUid }, categoryObj.cid, (err, topicCount) => {

--- a/test/controllers.js
+++ b/test/controllers.js
@@ -943,7 +943,50 @@ describe('Controllers', () => {
                         assert.ifError(err);
                         assert.equal(res.statusCode, 200);
                         assert(body);
-                        assert.equal(body.posts[0].content, 'test topic content');
+                        assert.equal(body.posts[0].content, 'test topic content', 'This post should be found because the group name is in the post title');
+                    });
+                });
+                topics.post({
+                    uid: fooUid,
+                    title: 'this is a post without the group title',
+                    content: 'not test topic content',
+                    cid: cid,
+                }, (err) => {
+                    assert.ifError(err);
+                    request(`${nconf.get('url')}/api/groups/group-details`, { json: true }, (err, res, body) => {
+                        assert.ifError(err);
+                        assert.equal(res.statusCode, 200);
+                        assert(body);
+                        assert.equal(body.posts[0].content, 'test topic content', 'This post should still exist from before');
+                        assert.equal(undefined, body.posts[1], 'There should not be a second post in this group');
+                        done();
+                    });
+                });
+            });
+        });
+    });
+
+    it('should load misc page and filter unmatched posts in that group', (done) => {
+        groups.create({
+            name: 'miscellaneous',
+            description: 'unmatched posts go here!',
+            hidden: 0,
+        }, (err) => {
+            assert.ifError(err);
+            groups.join('miscellaneous', fooUid, (err) => {
+                assert.ifError(err);
+                topics.post({
+                    uid: fooUid,
+                    title: 'this is an unmatched post',
+                    content: 'test topic content for misc',
+                    cid: cid,
+                }, (err) => {
+                    assert.ifError(err);
+                    request(`${nconf.get('url')}/api/groups/miscellaneous`, { json: true }, (err, res, body) => {
+                        assert.ifError(err);
+                        assert.equal(res.statusCode, 200);
+                        assert(body);
+                        assert.equal(body.posts[0].content, 'test topic content for misc');
                         done();
                     });
                 });
@@ -2208,7 +2251,10 @@ describe('Controllers', () => {
                             request(`${nconf.get('url')}/api/category/${category.slug}?sort=most_posts`, { jar: jar, json: true }, (err, res, body) => {
                                 assert.ifError(err);
                                 assert.equal(res.statusCode, 200);
-                                assert.equal(body.topics[0].title, 'topic 2');
+                                const time = body.topics[0].timestamp
+                                const originalTitle = body.topics[0].title;
+                                const updatedTitle = originalTitle.replace(/&#x2F;/g, '/');
+                                assert.equal(updatedTitle, 'topic 2' + ' (' + new Date(time).toLocaleString() + ')');
                                 assert.equal(body.topics[0].postcount, 2);
                                 assert.equal(body.topics[1].postcount, 1);
                                 next();
@@ -2241,7 +2287,10 @@ describe('Controllers', () => {
                             request(`${nconf.get('url')}/api/category/${category.slug}?tag=node&author=foo`, { jar: jar, json: true }, (err, res, body) => {
                                 assert.ifError(err);
                                 assert.equal(res.statusCode, 200);
-                                assert.equal(body.topics[0].title, 'topic 2');
+                                const time = body.topics[0].timestamp
+                                const originalTitle = body.topics[0].title;
+                                const updatedTitle = originalTitle.replace(/&#x2F;/g, '/');
+                                assert.equal(updatedTitle, 'topic 2' + ' (' + new Date(time).toLocaleString() + ')');
                                 next();
                             });
                         },
@@ -2249,8 +2298,15 @@ describe('Controllers', () => {
                             request(`${nconf.get('url')}/api/category/${category.slug}?tag[]=java&tag[]=cpp`, { jar: jar, json: true }, (err, res, body) => {
                                 assert.ifError(err);
                                 assert.equal(res.statusCode, 200);
-                                assert.equal(body.topics[0].title, 'topic 3');
-                                assert.equal(body.topics[1].title, 'topic 1');
+                                const time0 = body.topics[0].timestamp
+                                const originalTitle0 = body.topics[0].title;
+                                const updatedTitle0 = originalTitle0.replace(/&#x2F;/g, '/');
+                                assert.equal(updatedTitle0, 'topic 3' + ' (' + new Date(time0).toLocaleString() + ')');
+                                assert.equal(res.statusCode, 200);
+                                const time1 = body.topics[1].timestamp
+                                const originalTitle1 = body.topics[1].title;
+                                const updatedTitle1 = originalTitle1.replace(/&#x2F;/g, '/');
+                                assert.equal(updatedTitle1, 'topic 1' + ' (' + new Date(time1).toLocaleString() + ')');   
                                 next();
                             });
                         },

--- a/test/controllers.js
+++ b/test/controllers.js
@@ -2251,10 +2251,13 @@ describe('Controllers', () => {
                             request(`${nconf.get('url')}/api/category/${category.slug}?sort=most_posts`, { jar: jar, json: true }, (err, res, body) => {
                                 assert.ifError(err);
                                 assert.equal(res.statusCode, 200);
-                                const time = body.topics[0].timestamp
+                                const time = body.topics[0].timestamp;
                                 const originalTitle = body.topics[0].title;
                                 const updatedTitle = originalTitle.replace(/&#x2F;/g, '/');
-                                assert.equal(updatedTitle, 'topic 2' + ' (' + new Date(time).toLocaleString() + ')');
+                                const formattedTimestamp = new Date(time).toLocaleString();
+                                const expectedTitle = `topic 2 (${formattedTimestamp})`;
+
+                                assert.equal(updatedTitle, expectedTitle);
                                 assert.equal(body.topics[0].postcount, 2);
                                 assert.equal(body.topics[1].postcount, 1);
                                 next();
@@ -2287,10 +2290,13 @@ describe('Controllers', () => {
                             request(`${nconf.get('url')}/api/category/${category.slug}?tag=node&author=foo`, { jar: jar, json: true }, (err, res, body) => {
                                 assert.ifError(err);
                                 assert.equal(res.statusCode, 200);
-                                const time = body.topics[0].timestamp
+                                const time = body.topics[0].timestamp;
                                 const originalTitle = body.topics[0].title;
                                 const updatedTitle = originalTitle.replace(/&#x2F;/g, '/');
-                                assert.equal(updatedTitle, 'topic 2' + ' (' + new Date(time).toLocaleString() + ')');
+                                const formattedTimestamp = new Date(time).toLocaleString();
+                                const expectedTitle = `topic 2 (${formattedTimestamp})`;
+
+                                assert.equal(updatedTitle, expectedTitle);
                                 next();
                             });
                         },
@@ -2298,15 +2304,19 @@ describe('Controllers', () => {
                             request(`${nconf.get('url')}/api/category/${category.slug}?tag[]=java&tag[]=cpp`, { jar: jar, json: true }, (err, res, body) => {
                                 assert.ifError(err);
                                 assert.equal(res.statusCode, 200);
-                                const time0 = body.topics[0].timestamp
+                                const time0 = body.topics[0].timestamp;
                                 const originalTitle0 = body.topics[0].title;
                                 const updatedTitle0 = originalTitle0.replace(/&#x2F;/g, '/');
-                                assert.equal(updatedTitle0, 'topic 3' + ' (' + new Date(time0).toLocaleString() + ')');
+                                const formattedTimestamp0 = new Date(time0).toLocaleString();
+                                const expectedTitle0 = `topic 3 (${formattedTimestamp0})`;
+                                assert.equal(updatedTitle0, expectedTitle0);
                                 assert.equal(res.statusCode, 200);
-                                const time1 = body.topics[1].timestamp
+                                const time1 = body.topics[1].timestamp;
                                 const originalTitle1 = body.topics[1].title;
                                 const updatedTitle1 = originalTitle1.replace(/&#x2F;/g, '/');
-                                assert.equal(updatedTitle1, 'topic 1' + ' (' + new Date(time1).toLocaleString() + ')');   
+                                const formattedTimestamp1 = new Date(time1).toLocaleString();
+                                const expectedTitle1 = `topic 1 (${formattedTimestamp1})`;
+                                assert.equal(updatedTitle1, expectedTitle1);
                                 next();
                             });
                         },

--- a/test/groups.js
+++ b/test/groups.js
@@ -58,6 +58,15 @@ describe('Groups', () => {
             disableJoinRequests: 1,
         });
 
+        await Groups.create({
+            name: 'Miscellaneous',
+            userTitle: 'Miscellaneous',
+            description: 'Contains unmatched posts',
+            hidden: 0,
+            private: 1,
+            disableJoinRequests: 1,
+        });
+
         // Also create a hidden group
         await Groups.join('Hidden', 'Test');
         // create another group that starts with test for search/sort
@@ -80,7 +89,7 @@ describe('Groups', () => {
         it('should list the groups present', (done) => {
             Groups.getGroupsFromSet('groups:visible:createtime', 0, -1, (err, groups) => {
                 assert.ifError(err);
-                assert.equal(groups.length, 5);
+                assert.equal(groups.length, 6);
                 done();
             });
         });
@@ -128,7 +137,7 @@ describe('Groups', () => {
         it('should return the groups when search query is empty', (done) => {
             socketGroups.search({ uid: adminUid }, { query: '' }, (err, groups) => {
                 assert.ifError(err);
-                assert.equal(5, groups.length);
+                assert.equal(6, groups.length);
                 done();
             });
         });
@@ -667,6 +676,12 @@ describe('Groups', () => {
             await apiGroups.join({ uid: adminUid }, { slug: slug, uid: uid });
             const isGlobalMod = await User.isGlobalModerator(uid);
             assert.strictEqual(isGlobalMod, true);
+        });
+
+        it('should add user to Miscellaneous group', async () => {
+            const uid = await User.create({ username: 'glomod' });
+            const slug = await Groups.getGroupField('Miscellaneous', 'slug');
+            await apiGroups.join({ uid: adminUid }, { slug: slug, uid: uid });
         });
 
         it('should add user to multiple groups', (done) => {

--- a/test/posts.js
+++ b/test/posts.js
@@ -1099,10 +1099,12 @@ describe('Post\'s', () => {
             meta.config.groupsExemptFromPostQueue = ['registered-users'];
             const uid = await user.create({ username: 'mergeexemptuser' });
             const result = await apiTopics.create({ uid: uid, emit: () => {} }, { title: 'should not be queued', content: 'topic content', cid: cid });
-            const time = result.timestamp
-            const originalTitle = result.title
+            const time = result.timestamp;
+            const originalTitle = result.title;
             const updatedTitle = originalTitle.replace(/&#x2F;/g, '/');
-            assert.strictEqual(updatedTitle, 'should not be queued' + ' (' + new Date(time).toLocaleString() + ')');
+            const formattedTimestamp = new Date(time).toLocaleString();
+            const expectedTitle = `should not be queued (${formattedTimestamp})`;
+            assert.strictEqual(updatedTitle, expectedTitle);
             meta.config.groupsExemptFromPostQueue = oldValue;
         });
 

--- a/test/posts.js
+++ b/test/posts.js
@@ -1099,7 +1099,10 @@ describe('Post\'s', () => {
             meta.config.groupsExemptFromPostQueue = ['registered-users'];
             const uid = await user.create({ username: 'mergeexemptuser' });
             const result = await apiTopics.create({ uid: uid, emit: () => {} }, { title: 'should not be queued', content: 'topic content', cid: cid });
-            assert.strictEqual(result.title, 'should not be queued');
+            const time = result.timestamp
+            const originalTitle = result.title
+            const updatedTitle = originalTitle.replace(/&#x2F;/g, '/');
+            assert.strictEqual(updatedTitle, 'should not be queued' + ' (' + new Date(time).toLocaleString() + ')');
             meta.config.groupsExemptFromPostQueue = oldValue;
         });
 

--- a/test/search.js
+++ b/test/search.js
@@ -247,8 +247,10 @@ describe('Search', () => {
             },
             function (result, next) {
                 assert(result.posts.length, 2);
-                assert(result.posts[0].topic.title === 'child category topic');
-                assert(result.posts[1].topic.title === 'java mongodb redis');
+                const regexPattern0 = /^child category topic \((1[0-2]|0[1-9])&#x2F;(3[01]|[12][0-9]|0[1-9])&#x2F;\d{4}, (1[0-2]|[1-9]):([0-5][0-9]):([0-5][0-9]) (AM|PM)\)$/;
+                assert.ok(regexPattern0.test(result.posts[0].topic.title), `Topic title "${result.posts[0].topic.title}" does not match the expected pattern`);
+                const regexPattern1 = /^java mongodb redis \((1[0-2]|0[1-9])&#x2F;(3[01]|[12][0-9]|0[1-9])&#x2F;\d{4}, (1[0-2]|[1-9]):([0-5][0-9]):([0-5][0-9]) (AM|PM)\)$/;
+                assert.ok(regexPattern1.test(result.posts[1].topic.title), `Topic title "${result.posts[1].topic.title}" does not match the expected pattern`);
                 next();
             },
         ], done);

--- a/test/topics.js
+++ b/test/topics.js
@@ -92,10 +92,11 @@ describe('Topic\'s', () => {
                 assert(result);
                 topic.tid = result.topicData.tid;
                 const formattedTimestamp = new Date(Date.now()).toLocaleString();
-                assert.strictEqual( 
+                const expectedTitle = `Test Topic Title (${formattedTimestamp})`;
+                assert.strictEqual(
                     result.topicData.title.replace(/&#x2F;/g, '/'),
-                    'Test Topic Title' + ' (' + formattedTimestamp + ')'
-                );        
+                    expectedTitle
+                );
                 done();
             });
         });
@@ -618,9 +619,13 @@ describe('Topic\'s', () => {
             topics.post(topicPostData, (err, result) => {
                 assert.ifError(err);
                 topics.getTopicData(result.topicData.tid, (err, topicData) => {
+                    const formattedTimestamp0 = new Date(topicData.timestamp).toLocaleString();
+                    const formattedTimestamp1 = new Date(topicData.timestamp).toLocaleString().replace(/\//g, '&#x2F;');
+                    const expectedTitle = `${title} (${formattedTimestamp0})`;
+                    const expectedTitleEscaped = `${titleEscaped} (${formattedTimestamp1})`;
                     assert.ifError(err);
-                    assert.strictEqual(topicData.titleRaw, title + ' (' + new Date(topicData.timestamp).toLocaleString() + ')');
-                    assert.strictEqual(topicData.title, titleEscaped + ' (' + new Date(topicData.timestamp).toLocaleString().replace(/\//g, '&#x2F;') + ')');
+                    assert.strictEqual(topicData.titleRaw, expectedTitle);
+                    assert.strictEqual(topicData.title, expectedTitleEscaped);
                     done();
                 });
             });
@@ -1921,7 +1926,9 @@ describe('Topic\'s', () => {
             topics.getRelatedTopics(topicData, 0, (err, data) => {
                 assert.ifError(err);
                 assert(Array.isArray(data));
-                assert.equal(data[0].title.replace(/&#x2F;/g, '/'), 'topic title 2' + ' (' + new Date(data[0].timestamp).toLocaleString() + ')');
+                const formattedTimestamp = new Date(data[0].timestamp).toLocaleString();
+                const expectedTitle = `topic title 2 (${formattedTimestamp})`;
+                assert.equal(data[0].title.replace(/&#x2F;/g, '/'), expectedTitle);
                 meta.config.maximumRelatedTopics = 0;
                 done();
             });
@@ -2521,7 +2528,9 @@ describe('Topic\'s', () => {
             assert.equal(topic1.posts[1].content, 'topic 2 OP');
             assert.equal(topic1.posts[2].content, 'topic 1 reply');
             assert.equal(topic1.posts[3].content, 'topic 2 reply');
-            assert.equal(topic1.title.replace(/&#x2F;/g, '/'), 'topic 1' + ' (' + new Date(topic1.timestamp).toLocaleString() + ')');
+            const formattedTimestamp = new Date(topic1.timestamp).toLocaleString();
+            const expectedTitle = `topic 1 (${formattedTimestamp})`;
+            assert.equal(topic1.title.replace(/&#x2F;/g, '/'), expectedTitle);
         });
 
         it('should return properly for merged topic', (done) => {
@@ -2559,7 +2568,9 @@ describe('Topic\'s', () => {
             assert.equal(topic2.posts[1].content, 'topic 1 OP');
             assert.equal(topic2.posts[2].content, 'topic 1 reply');
             assert.equal(topic2.posts[3].content, 'topic 2 reply');
-            assert.equal(topic2.title.replace(/&#x2F;/g, '/'), 'topic 2' + ' (' + new Date(topic2.timestamp).toLocaleString() + ')');
+            const formattedTimestamp = new Date(topic2.timestamp).toLocaleString();
+            const expectedTitle = `topic 2 (${formattedTimestamp})`;
+            assert.equal(topic2.title.replace(/&#x2F;/g, '/'), expectedTitle);
         });
 
         it('should merge 2 topics with options newTopicTitle', async () => {
@@ -2590,7 +2601,9 @@ describe('Topic\'s', () => {
             assert.equal(topic3.posts[1].content, 'topic 2 OP');
             assert.equal(topic3.posts[2].content, 'topic 1 reply');
             assert.equal(topic3.posts[3].content, 'topic 2 reply');
-            assert.equal(topic3.title.replace(/&#x2F;/g, '/'), 'new merge topic' + ' (' + new Date(topic3.timestamp).toLocaleString() + ')');
+            const formattedTimestamp = new Date(topic3.timestamp).toLocaleString();
+            const expectedTitle = `new merge topic (${formattedTimestamp})`;
+            assert.equal(topic3.title.replace(/&#x2F;/g, '/'), expectedTitle);
         });
     });
 
@@ -2632,8 +2645,12 @@ describe('Topic\'s', () => {
                 stop: -1,
                 sort: 'recent',
             });
-            assert.strictEqual(data.topics[0].title.replace(/&#x2F;/g, '/'), 'most recent replied' + ' (' + new Date(data.topics[0].timestamp).toLocaleString() + ')');
-            assert.strictEqual(data.topics[1].title.replace(/&#x2F;/g, '/'), 'old replied' + ' (' + new Date(data.topics[1].timestamp).toLocaleString() + ')');
+            const formattedTimestamp0 = new Date(data.topics[0].timestamp).toLocaleString();
+            const expectedTitle0 = `most recent replied (${formattedTimestamp0})`;
+            const formattedTimestamp1 = new Date(data.topics[1].timestamp).toLocaleString();
+            const expectedTitle1 = `old replied (${formattedTimestamp1})`;
+            assert.strictEqual(data.topics[0].title.replace(/&#x2F;/g, '/'), expectedTitle0);
+            assert.strictEqual(data.topics[1].title.replace(/&#x2F;/g, '/'), expectedTitle1);
         });
 
         it('should get topics recent replied last', async () => {
@@ -2644,8 +2661,12 @@ describe('Topic\'s', () => {
                 stop: -1,
                 sort: 'old',
             });
-            assert.strictEqual(data.topics[0].title.replace(/&#x2F;/g, '/'), 'old replied' + ' (' + new Date(data.topics[0].timestamp).toLocaleString() + ')');
-            assert.strictEqual(data.topics[1].title.replace(/&#x2F;/g, '/'), 'most recent replied' + ' (' + new Date(data.topics[1].timestamp).toLocaleString() + ')');
+            const formattedTimestamp0 = new Date(data.topics[0].timestamp).toLocaleString();
+            const expectedTitle0 = `old replied (${formattedTimestamp0})`;
+            const formattedTimestamp1 = new Date(data.topics[1].timestamp).toLocaleString();
+            const expectedTitle1 = `most recent replied (${formattedTimestamp1})`;
+            assert.strictEqual(data.topics[0].title.replace(/&#x2F;/g, '/'), expectedTitle0);
+            assert.strictEqual(data.topics[1].title.replace(/&#x2F;/g, '/'), expectedTitle1);
         });
     });
 
@@ -2706,10 +2727,11 @@ describe('Topic\'s', () => {
             topicData = (await topics.post(topic)).topicData;
             topicData = await topics.getTopicData(topicData.tid);
             const formattedTimestamp = new Date(topicData.timestamp).toLocaleString();
+            const expectedTitle = `Scheduled Test Topic Title (${formattedTimestamp})`;
             assert.strictEqual(
-                'Scheduled Test Topic Title' + ' (' + formattedTimestamp + ')',
+                expectedTitle,
                 topicData.title.replace(/&#x2F;/g, '/')
-            );                 
+            );
         });
 
         it('should update poster\'s lastposttime with "action time"', async () => {

--- a/test/user.js
+++ b/test/user.js
@@ -1482,7 +1482,8 @@ describe('User', () => {
 
             const result = await Topics.post({ title: 'banned topic', content: 'tttttttttttt', cid: cid, uid: testUid });
             assert(result);
-            assert.strictEqual(result.topicData.title, 'banned topic');
+            const regexPattern = /^banned topic \((1[0-2]|0[1-9])&#x2F;(3[01]|[12][0-9]|0[1-9])&#x2F;\d{4}, (1[0-2]|[1-9]):([0-5][0-9]):([0-5][0-9]) (AM|PM)\)$/;
+            assert.ok(regexPattern.test(result.topicData.title), `Topic title "${result.topicData.title}" does not match the expected pattern`);
         });
     });
 


### PR DESCRIPTION
What: I've added tests for filtering posts into their respective groups including the miscellaneous group and for displaying the timestamp in a post title. I have also added all guidance for running my tests in a new UserGuide.md file found in the root directory. There is also a description of how to test some features. Please fill in whatever tests you have written and features you have made following the format of the existing file.

Why: These changes were added because we did not implement tests as we coded features. The user guide will be used to navigate our tests and new features.

How: This adapts the existing code that contains a default group for global moderators.

Anything Else: These tests address issue #16 #24 and #25 .

Screenshots: N/A; To view more information on the tests view UserGuide.md in root of directory.