### PR TITLE
Demonstrate issues on deepscan being fixed with added null check to src/privileges/posts.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ If you want to directly run the linting and testing commands with specific confi
 
 DeepScan is an advanced static code analysis tool that helps us maintain high code quality and catch potential issues in our JavaScript/TypeScript codebase.
 
-[![DeepScan Grade](https://deepscan.io/api/teams/22447/projects/25768/branches/811038/badge/grade.svg)](https://deepscan.io/dashboard#view=project&tid=22447&pid=25768&bid=811038)
+[![DeepScan Grade](https://deepscan.io/api/teams/22447/projects/25816/branches/813084/badge/grade.svg)](https://deepscan.io/dashboard#view=project&tid=22447&pid=25816&bid=813084)
 
 We've integrated DeepScan into our GitHub workflow. Every push to this repository's main branch triggers an analysis.
 

--- a/src/privileges/posts.js
+++ b/src/privileges/posts.js
@@ -79,7 +79,7 @@ privsPosts.filter = async function (privilege, pids, uid) {
     const tidToTopic = _.zipObject(tids, topicData);
 
     let cids = postData.map((post, index) => {
-        if (post != null){
+        if (post != null) {
             if (post) {
                 post.pid = pids[index];
                 post.topic = tidToTopic[post.tid];

--- a/src/privileges/posts.js
+++ b/src/privileges/posts.js
@@ -84,8 +84,9 @@ privsPosts.filter = async function (privilege, pids, uid) {
                 post.pid = pids[index];
                 post.topic = tidToTopic[post.tid];
             }
-        return tidToTopic[post.tid] && tidToTopic[post.tid].cid;
+            return tidToTopic[post.tid] && tidToTopic[post.tid].cid;
         }
+        return null
     }).filter(cid => parseInt(cid, 10));
 
     cids = _.uniq(cids);

--- a/src/privileges/posts.js
+++ b/src/privileges/posts.js
@@ -86,7 +86,7 @@ privsPosts.filter = async function (privilege, pids, uid) {
             }
             return tidToTopic[post.tid] && tidToTopic[post.tid].cid;
         }
-        return null
+        return null;
     }).filter(cid => parseInt(cid, 10));
 
     cids = _.uniq(cids);

--- a/src/privileges/posts.js
+++ b/src/privileges/posts.js
@@ -84,8 +84,8 @@ privsPosts.filter = async function (privilege, pids, uid) {
                 post.pid = pids[index];
                 post.topic = tidToTopic[post.tid];
             }
-        }
         return tidToTopic[post.tid] && tidToTopic[post.tid].cid;
+        }
     }).filter(cid => parseInt(cid, 10));
 
     cids = _.uniq(cids);


### PR DESCRIPTION
Refer to https://github.com/CMU-313/fall23-nodebb-fam/pull/46. 

Had to reinstall deepscan due to the workflow not working previously. 
This means the previous issues resolved in the last PR are no longer reflected in deepscan. 

To address this we added an additional commit to demonstrate another issue being fixed. We also updated the link in the readme file to reflect the new deepscan project.